### PR TITLE
Q13(py): fix not to use global variable in function

### DIFF
--- a/Question_11_20/answers_py/answer_13.py
+++ b/Question_11_20/answers_py/answer_13.py
@@ -21,7 +21,7 @@ def max_min_filter(img, K_size=3):
 		## Zero padding
 		pad = K_size // 2
 		out = np.zeros((H + pad * 2, W + pad * 2, 3), dtype=np.float)
-		out[pad: pad + H, pad: pad + W] = gray.copy().astype(np.float)
+		out[pad: pad + H, pad: pad + W] = img.copy().astype(np.float)
 		tmp = out.copy()
 
 		# filtering
@@ -38,7 +38,7 @@ def max_min_filter(img, K_size=3):
 		## Zero padding
 		pad = K_size // 2
 		out = np.zeros((H + pad * 2, W + pad * 2), dtype=np.float)
-		out[pad: pad + H, pad: pad + W] = gray.copy().astype(np.float)
+		out[pad: pad + H, pad: pad + W] = img.copy().astype(np.float)
 		tmp = out.copy()
 
 		# filtering


### PR DESCRIPTION
Modified to use the argument "img" instead of the global variable "gray" in max_min_filter function.

answer_14-19.py have the same problem, but support for multi-channel images is insufficient.
Therefore I fixed only answer_13.py.