### PR TITLE
fixed a bug

### DIFF
--- a/Question_21_30/answers_py/answer_29.py
+++ b/Question_21_30/answers_py/answer_29.py
@@ -41,7 +41,7 @@ def affine(img, a, b, c, d, tx, ty):
 _img = cv2.imread("imori.jpg").astype(np.float32)
 
 # Affine
-out = affine(img, a=1.3, b=0, c=0, d=0.8, tx=30, ty=-30)
+out = affine(_img, a=1.3, b=0, c=0, d=0.8, tx=30, ty=-30)
 
 
 # Save result


### PR DESCRIPTION
The bug is about "img" just like anwser_28.py.
Traceback (most recent call last):
File "/home/zpj/PycharmProjects/ObjectDetection/Question_100/Q29_Afine2.py", line 44, in
out = affine(img, a=1.3, b=0, c=0, d=0.8, tx=30, ty=-30)
NameError: name 'img' is not defined